### PR TITLE
Deploy setup: prod Kustomize overlay + k3s CI

### DIFF
--- a/.github/workflows/deploy-auth.yaml
+++ b/.github/workflows/deploy-auth.yaml
@@ -16,8 +16,9 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     - run: docker push ksburhan/auth
-    - uses: digitalocean/action-doctl@v2
-      with:
-        token: ${{ secrets.DOCTL_SECRET }}
-    - run: doctl kubernetes cluster kubeconfig save ticketing
+    - name: Configure kubeconfig
+      run: |
+        mkdir -p "$HOME/.kube"
+        echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+        chmod 600 "$HOME/.kube/config"
     - run: kubectl rollout restart deployment auth-depl

--- a/.github/workflows/deploy-client.yaml
+++ b/.github/workflows/deploy-client.yaml
@@ -16,8 +16,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - run: docker push ksburhan/client
-      - uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DOCTL_SECRET }}
-      - run: doctl kubernetes cluster kubeconfig save ticketing
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
       - run: kubectl rollout restart deployment client-depl

--- a/.github/workflows/deploy-expiration.yaml
+++ b/.github/workflows/deploy-expiration.yaml
@@ -16,8 +16,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - run: docker push ksburhan/expiration
-      - uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DOCTL_SECRET }}
-      - run: doctl kubernetes cluster kubeconfig save ticketing
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
       - run: kubectl rollout restart deployment expiration-depl

--- a/.github/workflows/deploy-manifest.yaml
+++ b/.github/workflows/deploy-manifest.yaml
@@ -14,4 +14,6 @@ jobs:
         with:
           token: ${{ secrets.DOCTL_SECRET }}
       - run: doctl kubernetes cluster kubeconfig save ticketing
-      - run: kubectl apply -f infra/k8s && kubectl apply -f infra/k8s-prod
+      # Prod is assembled via Kustomize (infra/kustomization.yaml): all
+      # services + ONE shared mongo + resource limits + TLS ingress.
+      - run: kubectl apply -k infra

--- a/.github/workflows/deploy-manifest.yaml
+++ b/.github/workflows/deploy-manifest.yaml
@@ -10,10 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DOCTL_SECRET }}
-      - run: doctl kubernetes cluster kubeconfig save ticketing
+      # Authenticate to the k3s cluster from a base64-encoded kubeconfig
+      # stored as the KUBE_CONFIG repo secret. Generate it once with:
+      #   base64 -i ~/.kube/config | pbcopy
+      # (kubeconfig must use the VPS public IP, not 127.0.0.1)
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
       # Prod is assembled via Kustomize (infra/kustomization.yaml): all
       # services + ONE shared mongo + resource limits + TLS ingress.
       - run: kubectl apply -k infra

--- a/.github/workflows/deploy-orders.yaml
+++ b/.github/workflows/deploy-orders.yaml
@@ -16,8 +16,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - run: docker push ksburhan/orders
-      - uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DOCTL_SECRET }}
-      - run: doctl kubernetes cluster kubeconfig save ticketing
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
       - run: kubectl rollout restart deployment orders-depl

--- a/.github/workflows/deploy-payments.yaml
+++ b/.github/workflows/deploy-payments.yaml
@@ -16,8 +16,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - run: docker push ksburhan/payments
-      - uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DOCTL_SECRET }}
-      - run: doctl kubernetes cluster kubeconfig save ticketing
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
       - run: kubectl rollout restart deployment payments-depl

--- a/.github/workflows/deploy-tickets.yaml
+++ b/.github/workflows/deploy-tickets.yaml
@@ -16,8 +16,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - run: docker push ksburhan/tickets
-      - uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DOCTL_SECRET }}
-      - run: doctl kubernetes cluster kubeconfig save ticketing
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
       - run: kubectl rollout restart deployment tickets-depl

--- a/infra/k8s-prod/cert-issuer.yaml
+++ b/infra/k8s-prod/cert-issuer.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@monkey-ticket.site
+    email: burhan.koeseler@hotmail.de
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:

--- a/infra/k8s-prod/cert-issuer.yaml
+++ b/infra/k8s-prod/cert-issuer.yaml
@@ -1,0 +1,18 @@
+# Let's Encrypt issuer for free, auto-renewed TLS.
+# Requires cert-manager to be installed in the cluster:
+#   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+# Change the email below before deploying (used for expiry notices).
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: admin@monkey-ticket.site
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/infra/k8s-prod/client-config.yml
+++ b/infra/k8s-prod/client-config.yml
@@ -3,4 +3,7 @@ kind: ConfigMap
 metadata:
   name: ticketing-config
 data:
-  BASE_URL: 'http://www.monkey-ticket.site'
+  # In-cluster URL for server-side rendering requests, so SSR doesn't hairpin
+  # through the public host and hit the http->https redirect. Browser-side
+  # requests use a relative '/' baseURL and go through the public ingress.
+  BASE_URL: 'http://ingress-nginx-controller.ingress-nginx.svc.cluster.local'

--- a/infra/k8s-prod/ingress-srv.yaml
+++ b/infra/k8s-prod/ingress-srv.yaml
@@ -4,8 +4,13 @@ metadata:
   name: ingress-service
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - www.monkey-ticket.site
+      secretName: monkey-ticket-tls
   rules:
     - host: www.monkey-ticket.site
       http:

--- a/infra/k8s-prod/mongo-shared-depl.yaml
+++ b/infra/k8s-prod/mongo-shared-depl.yaml
@@ -1,0 +1,63 @@
+# Single shared MongoDB for prod. Replaces the four per-service mongo
+# deployments from infra/k8s/* (which are NOT included by the prod
+# kustomization). Each service keeps its own logical database via a
+# distinct DB name in MONGO_URI (mongo-srv:27017/<service>), so the
+# "each service owns its DB" boundary is preserved.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  # No storageClassName: uses the cluster default (e.g. k3s local-path).
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongo
+  template:
+    metadata:
+      labels:
+        app: mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: mongo-data
+              mountPath: /data/db
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: mongo-data
+          persistentVolumeClaim:
+            claimName: mongo-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo-srv
+spec:
+  selector:
+    app: mongo
+  ports:
+    - name: db
+      protocol: TCP
+      port: 27017
+      targetPort: 27017

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -1,0 +1,185 @@
+# PRODUCTION assembly. Deploy with:  kubectl apply -k infra
+#
+# Local dev is unchanged: `skaffold dev` still applies infra/k8s/* and
+# infra/k8s-dev/* directly (4 separate mongos, no resource limits).
+#
+# This overlay deliberately does NOT include the four per-service
+# *-mongo-depl.yaml files from infra/k8s/. Instead it adds one shared
+# mongo (mongo-shared-depl.yaml) and repoints each service's MONGO_URI
+# to it below, keeping a distinct logical DB per service.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # --- base services (from infra/k8s, mongos intentionally excluded) ---
+  - k8s/auth-depl.yaml
+  - k8s/tickets-depl.yaml
+  - k8s/orders-depl.yaml
+  - k8s/payments-depl.yaml
+  - k8s/expiration-depl.yaml
+  - k8s/expiration-redis-depl.yaml
+  - k8s/nats-depl.yaml
+  - k8s/client-depl.yaml
+  # --- prod-only resources ---
+  - k8s-prod/mongo-shared-depl.yaml
+  - k8s-prod/client-config.yml
+  - k8s-prod/ingress-srv.yaml
+  - k8s-prod/cert-issuer.yaml
+
+patches:
+  # auth: point at shared mongo + add resource requests/limits
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: auth-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: auth
+                env:
+                  - name: MONGO_URI
+                    value: 'mongodb://mongo-srv:27017/auth'
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 250m
+                    memory: 192Mi
+  # tickets
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: tickets-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: tickets
+                env:
+                  - name: MONGO_URI
+                    value: 'mongodb://mongo-srv:27017/tickets'
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 250m
+                    memory: 192Mi
+  # orders
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: orders-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: orders
+                env:
+                  - name: MONGO_URI
+                    value: 'mongodb://mongo-srv:27017/orders'
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 250m
+                    memory: 192Mi
+  # payments
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: payments-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: payments
+                env:
+                  - name: MONGO_URI
+                    value: 'mongodb://mongo-srv:27017/payments'
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 250m
+                    memory: 192Mi
+  # expiration (no DB, resources only)
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: expiration-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: expiration
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 250m
+                    memory: 192Mi
+  # client (Next.js, a little more memory)
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: client-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: client
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 96Mi
+                  limits:
+                    cpu: 300m
+                    memory: 256Mi
+  # nats (container is literally named "name" in the base manifest)
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: nats-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: name
+                resources:
+                  requests:
+                    cpu: 25m
+                    memory: 32Mi
+                  limits:
+                    cpu: 150m
+                    memory: 128Mi
+  # redis
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: expiration-redis-depl
+      spec:
+        template:
+          spec:
+            containers:
+              - name: expiration-redis
+                resources:
+                  requests:
+                    cpu: 25m
+                    memory: 32Mi
+                  limits:
+                    cpu: 150m
+                    memory: 128Mi


### PR DESCRIPTION
## Summary
Prepares the project for a cheap, public single-VPS (k3s) deployment.
**Draft** — blocked on VPS provisioning before merge.

- **Prod Kustomize overlay** (`infra/kustomization.yaml`, `kubectl apply -k infra`):
  - 4 per-service MongoDBs → 1 shared `mongo-srv` (with PVC), each service keeps its own logical DB.
  - Resource requests/limits on every deployment for single-node scheduling.
  - Let's Encrypt `ClusterIssuer` + TLS ingress for `www.monkey-ticket.site`.
  - Client SSR `BASE_URL` points at the in-cluster ingress.
- **CI** retargeted from DigitalOcean to k3s via a `KUBE_CONFIG` secret (all deploy workflows).
- Local dev (`skaffold` + `infra/k8s`) is unchanged.

## Before merge (waiting on)
- [x] VPS + k3s provisioned
- [x] cluster prereqs: ingress-nginx, cert-manager
- [x] secrets: `jwt-secret`, `stripe-secret`; GitHub `KUBE_CONFIG`
- [ ] Hostinger DNS: `www` A record → VPS IP