### PR TITLE
infra: add readiness/liveness probes and harden shared mongo

### DIFF
--- a/infra/k8s-prod/cert-issuer.yaml
+++ b/infra/k8s-prod/cert-issuer.yaml
@@ -1,7 +1,3 @@
-# Let's Encrypt issuer for free, auto-renewed TLS.
-# Requires cert-manager to be installed in the cluster:
-#   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
-# Change the email below before deploying (used for expiry notices).
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/infra/k8s-prod/client-config.yml
+++ b/infra/k8s-prod/client-config.yml
@@ -3,7 +3,4 @@ kind: ConfigMap
 metadata:
   name: ticketing-config
 data:
-  # In-cluster URL for server-side rendering requests, so SSR doesn't hairpin
-  # through the public host and hit the http->https redirect. Browser-side
-  # requests use a relative '/' baseURL and go through the public ingress.
   BASE_URL: 'http://ingress-nginx-controller.ingress-nginx.svc.cluster.local'

--- a/infra/k8s-prod/mongo-shared-depl.yaml
+++ b/infra/k8s-prod/mongo-shared-depl.yaml
@@ -1,8 +1,3 @@
-# Single shared MongoDB for prod. Replaces the four per-service mongo
-# deployments from infra/k8s/* (which are NOT included by the prod
-# kustomization). Each service keeps its own logical database via a
-# distinct DB name in MONGO_URI (mongo-srv:27017/<service>), so the
-# "each service owns its DB" boundary is preserved.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,7 +8,6 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  # No storageClassName: uses the cluster default (e.g. k3s local-path).
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -21,6 +15,8 @@ metadata:
   name: mongo-depl
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: mongo
@@ -43,7 +39,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
       volumes:
         - name: mongo-data
           persistentVolumeClaim:

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -1,17 +1,7 @@
-# PRODUCTION assembly. Deploy with:  kubectl apply -k infra
-#
-# Local dev is unchanged: `skaffold dev` still applies infra/k8s/* and
-# infra/k8s-dev/* directly (4 separate mongos, no resource limits).
-#
-# This overlay deliberately does NOT include the four per-service
-# *-mongo-depl.yaml files from infra/k8s/. Instead it adds one shared
-# mongo (mongo-shared-depl.yaml) and repoints each service's MONGO_URI
-# to it below, keeping a distinct logical DB per service.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  # --- base services (from infra/k8s, mongos intentionally excluded) ---
   - k8s/auth-depl.yaml
   - k8s/tickets-depl.yaml
   - k8s/orders-depl.yaml
@@ -20,14 +10,12 @@ resources:
   - k8s/expiration-redis-depl.yaml
   - k8s/nats-depl.yaml
   - k8s/client-depl.yaml
-  # --- prod-only resources ---
   - k8s-prod/mongo-shared-depl.yaml
   - k8s-prod/client-config.yml
   - k8s-prod/ingress-srv.yaml
   - k8s-prod/cert-issuer.yaml
 
 patches:
-  # auth: point at shared mongo + add resource requests/limits
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -48,7 +36,16 @@ patches:
                   limits:
                     cpu: 250m
                     memory: 192Mi
-  # tickets
+                readinessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -69,7 +66,16 @@ patches:
                   limits:
                     cpu: 250m
                     memory: 192Mi
-  # orders
+                readinessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -90,7 +96,16 @@ patches:
                   limits:
                     cpu: 250m
                     memory: 192Mi
-  # payments
+                readinessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -111,7 +126,16 @@ patches:
                   limits:
                     cpu: 250m
                     memory: 192Mi
-  # expiration (no DB, resources only)
+                readinessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -129,7 +153,6 @@ patches:
                   limits:
                     cpu: 250m
                     memory: 192Mi
-  # client (Next.js, a little more memory)
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -147,7 +170,16 @@ patches:
                   limits:
                     cpu: 300m
                     memory: 256Mi
-  # nats (container is literally named "name" in the base manifest)
+                readinessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                livenessProbe:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -165,7 +197,6 @@ patches:
                   limits:
                     cpu: 150m
                     memory: 128Mi
-  # redis
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment


### PR DESCRIPTION
Add TCP probes on :3000 to auth, tickets, orders, payments, and client so rollouts and restarts no longer route traffic to not-yet-ready pods (avoids 502s). Expiration is a worker with no HTTP server, so it gets none.

Harden the shared mongo: strategy Recreate so the single-writer PVC isn't contended during rollouts, and raise the memory limit to 1Gi to avoid OOM kills under load. Also strip explanatory comments from the prod manifests.