### PR TITLE
build: run client as a production Next.js build, not the dev server

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,18 @@
-FROM node:alpine
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 COPY package.json .
-RUN npm install --omit=dev
+RUN npm install
 COPY . .
+RUN npm run build
 
-CMD ["npm", "run", "dev"]
+FROM node:20-alpine
+
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json .
+RUN npm install --omit=dev
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/next.config.js ./next.config.js
+
+CMD ["npm", "start"]

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next",
     "dev:mock": "NEXT_PUBLIC_USE_MOCKS=1 next dev",
-    "dev:mock:signedout": "NEXT_PUBLIC_USE_MOCKS=1 NEXT_PUBLIC_MOCK_SIGNED_OUT=1 next dev"
+    "dev:mock:signedout": "NEXT_PUBLIC_USE_MOCKS=1 NEXT_PUBLIC_MOCK_SIGNED_OUT=1 next dev",
+    "build": "next build",
+    "start": "next start"
   },
   "keywords": [],
   "author": "",

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -169,7 +169,7 @@ patches:
                     memory: 96Mi
                   limits:
                     cpu: 300m
-                    memory: 256Mi
+                    memory: 384Mi
                 readinessProbe:
                   tcpSocket:
                     port: 3000


### PR DESCRIPTION
The client image ran 'next' (dev server) in production, which compiles on demand and is memory-hungry, so it OOMKilled at the 256Mi limit (64 restarts, 503 on the homepage). Add build/start scripts and a multi-stage Dockerfile that runs 'next build' then 'next start' on pinned node:20-alpine. Production Next uses a fraction of the memory; bump the client limit to 384Mi for headroom. Local dev still uses 'npm run dev'.